### PR TITLE
Bugfix: Improper pseudo-elements handling

### DIFF
--- a/example/src/app.jsx
+++ b/example/src/app.jsx
@@ -6,6 +6,7 @@ import Gallery from "./components/Gallery/Gallery";
 
 import appStyles from "./app.component.scss";
 import Footer from "./components/Footer/Footer";
+import Form from "./components/Form/Form";
 
 const App = () => {
 	return (
@@ -70,6 +71,9 @@ const App = () => {
 						Gallery <pre>className="grid"</pre>
 					</h1>
 					<Gallery />
+				</section>
+				<section>
+					<Form />
 				</section>
 				<Footer />
 			</div>

--- a/example/src/components/Form/Form.component.scss
+++ b/example/src/components/Form/Form.component.scss
@@ -1,0 +1,21 @@
+@scope tree;
+
+form {
+	padding: 2rem;
+	margin-top: 3rem;
+	border-radius: 10px;
+	background-color: white;
+	color: #333;
+
+	select {
+		appearance: base-select;
+	}
+
+	::picker(select) {
+		appearance: base-select;
+	}
+
+	::picker(select):popover-open {
+		color: red;
+	}
+}

--- a/example/src/components/Form/Form.jsx
+++ b/example/src/components/Form/Form.jsx
@@ -1,0 +1,27 @@
+import style from "./Form.component.scss";
+
+function Form() {
+	return (
+		<form data-style={style}>
+			<div>
+				<label htmlFor="name">Name:</label>
+				<input type="text" id="name" name="name" required />
+			</div>
+			<div>
+				<label htmlFor="email">Email:</label>
+				<input type="email" id="email" name="email" required />
+			</div>
+			<div>
+				<label htmlFor="color">Favorite color:</label>
+				<select name="color" id="color">
+					<option value="#f00">Red</option>
+					<option value="#0f0">Green</option>
+					<option value="#00f">Blue</option>
+				</select>
+			</div>
+			<button type="submit">Submit</button>
+		</form>
+	);
+}
+
+export default Form;

--- a/src/cssScopeLoader.js
+++ b/src/cssScopeLoader.js
@@ -1,6 +1,7 @@
 const { parse, generate, toPlainObject, fromPlainObject, walk } = require("css-tree");
 const { validate } = require("schema-utils");
 const beautify = require("js-beautify");
+const util = require("util");
 
 const schema = {
 	type: "object",
@@ -157,10 +158,23 @@ module.exports = function (source) {
 	function modifySelector(selector) {
 		let combinatorPos = selector.children.findIndex(node => node.type === "Combinator");
 		let pseudoElementPos = selector.children.findIndex(node => node.type === "PseudoElementSelector");
-		let pseudoElement;
+		let pseudoElementsAndAfter = [];
 
 		if (pseudoElementPos !== -1) {
-			[pseudoElement] = selector.children.splice(pseudoElementPos, 1);
+			// Check if pseudo element is right after a combinator
+			const isPseudoAfterCombinator =
+				pseudoElementPos === 0 || selector.children[pseudoElementPos - 1].type === "Combinator";
+
+			if (!isPseudoAfterCombinator) {
+				// Find the next combinator after the pseudo element, or use end of array
+				let nextCombinatorPos = selector.children.findIndex(
+					(node, index) => index > pseudoElementPos && node.type === "Combinator"
+				);
+				if (nextCombinatorPos === -1) nextCombinatorPos = selector.children.length;
+
+				// Extract pseudo element and all elements after it up to next combinator
+				pseudoElementsAndAfter = selector.children.splice(pseudoElementPos, nextCombinatorPos - pseudoElementPos);
+			}
 		}
 
 		let hasCombinator = combinatorPos != -1;
@@ -170,7 +184,7 @@ module.exports = function (source) {
 		selector.children[2]?.type === "PseudoElementSelector" && console.log(selector);
 
 		if (!hasCombinator || options.scopeEnd === "tree") {
-			pseudoElement && selector.children.push(pseudoElement);
+			pseudoElementsAndAfter.length > 0 && selector.children.push(...pseudoElementsAndAfter);
 			return selector;
 		}
 
@@ -190,7 +204,7 @@ module.exports = function (source) {
 			])
 		);
 
-		pseudoElement && selector.children.push(pseudoElement);
+		pseudoElementsAndAfter.length > 0 && selector.children.push(...pseudoElementsAndAfter);
 		return selector;
 	}
 


### PR DESCRIPTION
Closes #5

#### This PR changes handling of pseudo elements in the following ways:
- When a pseudo element is found in a selector, it and all subsequent elements up to the next combinator (or the end of the selector) are moved to the end of the selector.
- If the pseudo element is immediately after a combinator, it and the following elements are left in place and not moved.
- This ensures that pseudo elements and related trailing nodes are only moved when appropriate, improving the accuracy of selector transformation for scoped CSS.

For description of previous behavior refer to #5.